### PR TITLE
Cache metadata until file changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=5.5.9",
         "league/csv": "^7.1",
         "illuminate/support": "^5.1",
-        "illuminate/contracts": "^5.1"
+        "illuminate/contracts": "^5.1",
+        "illuminate/cache": "^5.1"
     },
     "require-dev": {
         "fabpot/php-cs-fixer": "2.0.*@dev",

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -95,7 +95,8 @@ class Metadata
      */
     public function setMetadataFromFile($file)
     {
-        foreach ($this->getEntriesFromCache($file) as $entry) {
+        $entries = $this->getEntriesFromCache($file);
+        foreach ($entries as $entry) {
             if (strpos($this->url->current(), $entry['url']) !== false) {
                 $this->setMetadata($entry);
             }
@@ -177,7 +178,7 @@ class Metadata
     }
 
     /**
-     * @param $file
+     * @param string $file
      *
      * @return array
      */
@@ -187,7 +188,7 @@ class Metadata
     }
 
     /**
-     * @param $file
+     * @param string $file
      *
      * @return array
      */
@@ -200,7 +201,7 @@ class Metadata
             if (!$this->isModified($cached, $lastModifiedAt)) {
                 return $cached['meta'];
             }
-        };
+        }
 
         $entries = $this->getEntriesFromCSV($file);
 
@@ -213,7 +214,7 @@ class Metadata
     }
 
     /**
-     * @param $file
+     * @param string $file
      *
      * @return string
      */

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -55,13 +55,18 @@ class Metadata
 
     /**
      * @param UrlGenerator $url
-     * @param Store $cache
-     * @param null $publicFolder
+     * @param Store        $cache
+     * @param null         $publicFolder
      */
     public function __construct(UrlGenerator $url, Store $cache, $publicFolder = null)
     {
-        $this->url = $url;
-        $this->cache = $cache->tags('arrounded.meta');
+        $this->url   = $url;
+        $this->cache = $cache;
+
+        if (method_exists($this->cache, 'tags')) {
+            $this->cache = $cache->tags('arrounded.meta');
+        }
+
         $this->publicFolder = $publicFolder;
     }
 
@@ -183,7 +188,7 @@ class Metadata
      *
      * @return array
      */
-    protected function getEntriesFromCSV($file)
+    protected function getEntriesFromCsv($file)
     {
         return Reader::createFromPath($file)->fetchAssoc(0);
     }
@@ -198,7 +203,7 @@ class Metadata
         $identifier = $this->getCacheIdentifier($file);
 
         return $this->cache->rememberForever($identifier, function () use ($file) {
-            return $this->getEntriesFromCSV($file);
+            return $this->getEntriesFromCsv($file);
         });
     }
 

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -26,7 +26,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
     public function register()
     {
         $this->app->singleton('arrounded.meta', function ($app) {
-            return new Metadata($app['url'], $app['path.public']);
+            return new Metadata($app['url'], $app['cache.store'], $app['path.public']);
         });
     }
 

--- a/tests/MetadataTest.php
+++ b/tests/MetadataTest.php
@@ -139,16 +139,14 @@ EOF;
     {
         $file = __DIR__.'/test.csv';
 
-        $cache = new ArrayStore();
-        $cache->forever('arrounded.meta.'.$file, [
-            'last_modified_at' => (new SplFileInfo($file))->getMTime(),
-            'meta' => [
-                [
-                    'url' => 'foo.com',
-                    'title' => 'Bar',
-                    'keywords' => 'bar;foo',
-                    'description' => 'Barfoo',
-                ]
+        $cache = (new ArrayStore());
+        $modifiedAt = (new SplFileInfo($file))->getMTime();
+        $cache->tags('arrounded.meta')->forever('arrounded.meta.'.$file.$modifiedAt, [
+            [
+                'url' => 'foo.com',
+                'title' => 'Bar',
+                'keywords' => 'bar;foo',
+                'description' => 'Barfoo',
             ]
         ]);
 


### PR DESCRIPTION
### Changed
- Metadata retrieved from a CSV file is now cached until said file has changed
